### PR TITLE
Fix mavis config TypeError when a single, invalid tool is given

### DIFF
--- a/src/mavis_config/constants.py
+++ b/src/mavis_config/constants.py
@@ -57,7 +57,9 @@ class MavisNamespace(metaclass=EnumType):
             ....
         """
         if value not in cls.values():
-            raise KeyError('value {0} is not a valid member of '.format(repr(value)), cls.values())
+            raise KeyError(
+                'value {0} is not a valid member of {1}'.format(repr(value), cls.values())
+            )
         return value
 
     @classmethod


### PR DESCRIPTION
Instead of raising the intended KeyError, a TypeError was being raised when 'self.values()' is None. This happens when a single tool is given as input and that tool is invalid.